### PR TITLE
HiFiC Updates

### DIFF
--- a/models/hific/README.md
+++ b/models/hific/README.md
@@ -1,7 +1,5 @@
 # High-Fidelity Generative Image Compression
 
-## PRE-RELEASE
-
 <div align="center">
   <a href='https://hific.github.io'>
   <img src='https://hific.github.io/social/thumb.jpg' width="80%"/>
@@ -95,7 +93,6 @@ If you get slow training/stalling, try tweaking the `DATASET_NUM_PARALLEL` and
 
 The architecture is defined in `arch.py`, which is used to build the model from
 `model.py`. Our configurations are in `configs.py`.
-
 
 We release a _simplified_ trainer in `train.py` as a starting point for custom
 training. Note that it's using

--- a/models/hific/archs.py
+++ b/models/hific/archs.py
@@ -87,7 +87,7 @@ class Encoder(tf.keras.Sequential):
     model = [
         tf.keras.layers.Conv2D(
             filters=num_filters_base, kernel_size=7, padding="same"),
-        LayerNorm(),
+        ChannelNorm(),
         tf.keras.layers.ReLU()
     ]
 
@@ -96,7 +96,7 @@ class Encoder(tf.keras.Sequential):
           tf.keras.layers.Conv2D(
               filters=num_filters_base * 2 ** (i + 1),
               kernel_size=3, padding="same", strides=2),
-          LayerNorm(),
+          ChannelNorm(),
           tf.keras.layers.ReLU()])
 
     model.append(
@@ -128,11 +128,11 @@ class Decoder(tf.keras.layers.Layer):
       num_filters_base: base number of filters.
       num_residual_blocks: number of residual blocks.
     """
-    head = [LayerNorm(),
+    head = [ChannelNorm(),
             tf.keras.layers.Conv2D(
                 filters=num_filters_base * (2 ** num_up),
                 kernel_size=3, padding="same"),
-            LayerNorm()]
+            ChannelNorm()]
 
     residual_blocks = []
     for block_idx in range(num_residual_blocks):
@@ -152,7 +152,7 @@ class Decoder(tf.keras.layers.Layer):
               filters=filters,
               kernel_size=3, padding="same",
               strides=2),
-          LayerNorm(),
+          ChannelNorm(),
           tf.keras.layers.ReLU()]
 
     # Final conv layer.
@@ -202,10 +202,10 @@ class ResidualBlock(tf.keras.layers.Layer):
 
     block = [
         tf.keras.layers.Conv2D(**kwargs_conv2d),
-        LayerNorm(),
+        ChannelNorm(),
         tf.keras.layers.Activation(activation),
         tf.keras.layers.Conv2D(**kwargs_conv2d),
-        LayerNorm()]
+        ChannelNorm()]
 
     self.block = tf.keras.Sequential(name=name, layers=block)
 
@@ -213,8 +213,8 @@ class ResidualBlock(tf.keras.layers.Layer):
     return inputs + self.block(inputs, **kwargs)
 
 
-class LayerNorm(tf.keras.layers.Layer):
-  """Implement LayerNorm.
+class ChannelNorm(tf.keras.layers.Layer):
+  """Implement ChannelNorm.
 
   Based on this paper and keras' InstanceNorm layer:
     Ba, Jimmy Lei, Jamie Ryan Kiros, and Geoffrey E. Hinton.
@@ -239,7 +239,7 @@ class LayerNorm(tf.keras.layers.Layer):
       gamma_initializer: Initializer for gamma.
       **kwargs: Passed to keras.
     """
-    super(LayerNorm, self).__init__(**kwargs)
+    super(ChannelNorm, self).__init__(**kwargs)
 
     self.axis = -1
     self.epsilon = epsilon

--- a/models/hific/archs.py
+++ b/models/hific/archs.py
@@ -20,6 +20,7 @@ The default values for all constructors reflect what was used in the paper.
 """
 
 import collections
+import os
 from compare_gan.architectures import abstract_arch
 from compare_gan.architectures import arch_ops
 import numpy as np
@@ -529,7 +530,7 @@ class Hyperprior(tf.keras.layers.Layer):
 
     compressed = None
     if training:
-      latents_decoded = _quantize(latents, latent_means)
+      latents_decoded = _ste_quantize(latents, latent_means)
     elif validation:
       latents_decoded = entropy_info.quantized
     else:
@@ -552,10 +553,17 @@ class Hyperprior(tf.keras.layers.Layer):
     tf.summary.scalar("bpp/total/noisy", info.total_nbpp)
     tf.summary.scalar("bpp/total/quantized", info.total_qbpp)
 
+    tf.summary.scalar("bpp/latent/noisy", entropy_info.nbpp)
+    tf.summary.scalar("bpp/latent/quantized", entropy_info.qbpp)
+
+    tf.summary.scalar("bpp/side/noisy", side_info.total_nbpp)
+    tf.summary.scalar("bpp/side/quantized", side_info.total_qbpp)
+
     return info
 
 
-def _quantize(inputs, mean):
+def _ste_quantize(inputs, mean):
+  """Calculates quantize(inputs - mean) + mean, sets straight-through grads."""
   half = tf.constant(.5, dtype=tf.float32)
   outputs = inputs
   outputs -= mean

--- a/models/hific/archs.py
+++ b/models/hific/archs.py
@@ -62,7 +62,7 @@ HyperInfo = collections.namedtuple(
     "HyperInfo",
     "decoded latent_shape hyper_latent_shape "
     "nbpp side_nbpp total_nbpp qbpp side_qbpp total_qbpp "
-    "bitstring side_bitstring",
+    "bitstream_tensors",
 )
 
 
@@ -480,6 +480,14 @@ class Hyperprior(tf.keras.layers.Layer):
     self._side_entropy_model = FactorizedPriorLayer()
 
   @property
+  def losses(self):
+    return self._side_entropy_model.losses
+
+  @property
+  def updates(self):
+    return self._side_entropy_model.updates
+
+  @property
   def transform_layers(self):
     return [self._analysis, self._synthesis_scale, self._synthesis_mean]
 
@@ -547,8 +555,10 @@ class Hyperprior(tf.keras.layers.Layer):
         qbpp=entropy_info.qbpp,
         side_qbpp=side_info.total_qbpp,
         total_qbpp=entropy_info.qbpp + side_info.total_qbpp,
-        bitstring=compressed,
-        side_bitstring=side_info.bitstring)
+        # We put everything that's needed for real arithmetic coding into
+        # the bistream_tensors tuple.
+        bitstream_tensors=(compressed, side_info.bitstring,
+                           image_shape, latent_shape, side_info.latent_shape))
 
     tf.summary.scalar("bpp/total/noisy", info.total_nbpp)
     tf.summary.scalar("bpp/total/quantized", info.total_qbpp)

--- a/models/hific/colab.ipynb
+++ b/models/hific/colab.ipynb
@@ -172,10 +172,7 @@
         "#@markdown Different models target different bitrates.\n",
         "\n",
         "model = 'hific-lo' #@param [\"hific-lo\", \"hific-mi\", \"hific-hi\"]\n",
-        "\n",
-        "print(f'Caching model \"{model}\"...')\n",
-        "tfci.import_metagraph(model)\n",
-        "print('Done')\n"
+        "\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -216,6 +213,19 @@
         "  img = img.resize((w // 15, h // 15))\n",
         "  print('- ' + file_name + ':')\n",
         "  display(img)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "46eq2rCRpXzC"
+      },
+      "source": [
+        "print(f'Caching model \"{model}\"...')\n",
+        "tfci.import_metagraph(model)\n",
+        "print('Done')"
       ],
       "execution_count": null,
       "outputs": []

--- a/models/hific/colab.ipynb
+++ b/models/hific/colab.ipynb
@@ -18,6 +18,20 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "ErOf16E05Dn7"
+      },
+      "source": [
+        "# High-Fidelity Generative Image Compression\n",
+        "\n",
+        "This colab can be used to compress images using HiFiC. This can also be achieved\n",
+        "by running `tfci.py`, as [explained in the README](https://github.com/tensorflow/compression/tree/master/models/hific#running-models-trained-by-us-locally).\n",
+        "\n",
+        "Please visit [hific.github.io](https://hific.github.io) for more information."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "Umer7W0VbITT"
       },
       "source": [
@@ -159,7 +173,7 @@
         "\n",
         "model = 'hific-lo' #@param [\"hific-lo\", \"hific-mi\", \"hific-hi\"]\n",
         "\n",
-        "print('Caching model...')\n",
+        "print(f'Caching model \"{model}\"...')\n",
         "tfci.import_metagraph(model)\n",
         "print('Done')\n"
       ],
@@ -189,12 +203,12 @@
       "source": [
         "all_files = os.listdir(FILES_DIR)\n",
         "if not upload_custom_images or not all_files:\n",
-        "  print('Downloading default...')\n",
+        "  print('Downloading default image...')\n",
         "  get_default_image(FILES_DIR)\n",
         "  print()\n",
         "\n",
         "all_files = os.listdir(FILES_DIR)\n",
-        "print(f'Got following files ({len(all_files)}):')\n",
+        "print(f'Got the following files ({len(all_files)}):')\n",
         "\n",
         "for file_name in all_files:\n",
         "  img = Image.open(os.path.join(FILES_DIR, file_name))\n",
@@ -259,7 +273,7 @@
         "           get_bpp(Image.open(full_path).size, num_bytes)))\n",
         "    continue\n",
         "\n",
-        "  print('Compressing', file_name, '...')\n",
+        "  print('Compressing', file_name, 'with', model, '...')\n",
         "  tfci.compress(model, full_path, compressed_path)\n",
         "  num_bytes = os.path.getsize(compressed_path)\n",
         "  print(f'Compressed to {num_bytes} bytes.')\n",

--- a/models/hific/colab.ipynb
+++ b/models/hific/colab.ipynb
@@ -5,7 +5,8 @@
     "colab": {
       "name": "HiFiC_Interactive_Colab.ipynb",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -17,7 +18,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Umer7W0VbITT"
       },
       "source": [
@@ -27,9 +27,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "LO_MNEQ7Bhbw",
-        "colab": {}
+        "id": "LO_MNEQ7Bhbw"
       },
       "source": [
         "%tensorflow_version 1.x\n",
@@ -44,7 +42,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "op4hPwy_mkPm"
       },
       "source": [
@@ -58,9 +55,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "x-yLUG_tmo3M",
-        "colab": {}
+        "id": "x-yLUG_tmo3M"
       },
       "source": [
         "import tensorflow as tf\n",
@@ -76,7 +71,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rQ9-8ZsTf7Hj"
       },
       "source": [
@@ -86,9 +80,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "vtd1l70Pf95V",
-        "colab": {}
+        "id": "vtd1l70Pf95V"
       },
       "source": [
         "import os\n",
@@ -109,9 +101,6 @@
         "DEFAULT_IMAGE_URL = ('https://storage.googleapis.com/hific/clic2020/'\n",
         "                     'images/originals/ad249bba099568403dc6b97bc37f8d74.png')\n",
         "\n",
-        "MODEL = 'hific-lo'\n",
-        "TMP_OUT = 'out.tfci'\n",
-        "\n",
         "os.makedirs(FILES_DIR, exist_ok=True)\n",
         "os.makedirs(OUT_DIR, exist_ok=True)\n",
         "\n",
@@ -128,12 +117,7 @@
         "  output_path = os.path.join(output_dir, os.path.basename(DEFAULT_IMAGE_URL))\n",
         "  print('Downloading', DEFAULT_IMAGE_URL, '\\n->', output_path)\n",
         "  urllib.request.urlretrieve(DEFAULT_IMAGE_URL, output_path)\n",
-        "\n",
-        "\n",
-        "print('Caching model...')\n",
-        "tfci.import_metagraph(MODEL)\n",
-        "print('Done')\n",
-        "      "
+        "\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -141,7 +125,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "4Ngs9WvmbTMH"
       },
       "source": [
@@ -151,26 +134,34 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "NgtIlL2ADCI2",
-        "colab": {}
+        "id": "NgtIlL2ADCI2"
       },
       "source": [
-        "#@title Loading Images { vertical-output: false, run: \"auto\", display-mode: \"form\" }\n",
+        "#@title Setup { vertical-output: false, run: \"auto\", display-mode: \"form\" }\n",
+        "#@markdown #### Custom Images\n",
         "#@markdown Tick the following if you want to upload your own images to compress.\n",
         "#@markdown Otherwise, a default image will be used.\n",
         "#@markdown \n",
         "#@markdown **Note**: We support JPG and PNG (without alpha channels).\n",
         "#@markdown \n",
         "\n",
-        "upload_custom_images = False #@param {type:\"boolean\"}\n",
+        "upload_custom_images = False #@param {type:\"boolean\", label:\"HI\"}\n",
         "\n",
         "if upload_custom_images:\n",
         "  uploaded = files.upload()\n",
         "  for name, content in uploaded.items():\n",
         "    with open(os.path.join(FILES_DIR, name), 'wb') as fout:\n",
         "      print('Writing', name, '...')\n",
-        "      fout.write(content)\n"
+        "      fout.write(content)\n",
+        "\n",
+        "#@markdown #### Select a model\n",
+        "#@markdown Different models target different bitrates.\n",
+        "\n",
+        "model = 'hific-lo' #@param [\"hific-lo\", \"hific-mi\", \"hific-hi\"]\n",
+        "\n",
+        "print('Caching model...')\n",
+        "tfci.import_metagraph(model)\n",
+        "print('Done')\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -178,9 +169,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "e0C4vMqZsnqA",
-        "colab_type": "code",
-        "colab": {}
+        "id": "GYcbc2HupTRD"
+      },
+      "source": [
+        "if 'upload_custom_images' not in locals():\n",
+        "  print('ERROR: Please run the previous cell!')\n",
+        "  # Setting defaults anyway.\n",
+        "  upload_custom_images = False\n",
+        "  model = 'hific-lo'"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "e0C4vMqZsnqA"
       },
       "source": [
         "all_files = os.listdir(FILES_DIR)\n",
@@ -205,8 +209,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "guX3Q_AsTE7-",
-        "colab_type": "text"
+        "id": "guX3Q_AsTE7-"
       },
       "source": [
         "# Compress images"
@@ -215,9 +218,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "kd02HOhLBj6e",
-        "colab": {}
+        "id": "kd02HOhLBj6e"
       },
       "source": [
         "SUPPORTED_EXT = {'.png', '.jpg'}\n",
@@ -246,17 +247,25 @@
         "    print('Skipping because of alpha channel:', file_name)\n",
         "    continue\n",
         "  file_name, _ = os.path.splitext(file_name)\n",
-        "  output_path = os.path.join(OUT_DIR, f'{file_name}.png')\n",
+        "\n",
+        "  compressed_path = os.path.join(OUT_DIR, f'{file_name}_{model}.tfci')\n",
+        "  output_path = os.path.join(OUT_DIR, f'{file_name}_{model}.png')\n",
+        "  \n",
         "  if os.path.isfile(output_path):\n",
-        "    print('Skipping', output_path, '-- exists already.')\n",
+        "    print('Exists already:', output_path)\n",
+        "    num_bytes = os.path.getsize(compressed_path)\n",
+        "    all_outputs.append(\n",
+        "      File(output_path, num_bytes,\n",
+        "           get_bpp(Image.open(full_path).size, num_bytes)))\n",
         "    continue\n",
         "\n",
         "  print('Compressing', file_name, '...')\n",
-        "  tfci.compress(MODEL, full_path, TMP_OUT)\n",
-        "  num_bytes = os.path.getsize(TMP_OUT)\n",
+        "  tfci.compress(model, full_path, compressed_path)\n",
+        "  num_bytes = os.path.getsize(compressed_path)\n",
+        "  print(f'Compressed to {num_bytes} bytes.')\n",
         "\n",
         "  print('Decompressing...')\n",
-        "  tfci.decompress(TMP_OUT, output_path)\n",
+        "  tfci.decompress(compressed_path, output_path)\n",
         "  \n",
         "  all_outputs.append(\n",
         "      File(output_path, num_bytes,\n",
@@ -270,8 +279,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "HQhQQs-CTkgy",
-        "colab_type": "text"
+        "id": "HQhQQs-CTkgy"
       },
       "source": [
         "# Show output"
@@ -280,9 +288,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "3nVCPeDnskD8",
-        "colab": {}
+        "id": "3nVCPeDnskD8"
       },
       "source": [
         "make_cell_large()  # Larger output window.\n",
@@ -299,8 +305,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4b-wkBnyrTAR",
-        "colab_type": "text"
+        "id": "4b-wkBnyrTAR"
       },
       "source": [
         "### Download all compressed images.\n",
@@ -317,9 +322,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "9BKccvcTpj1k",
-        "colab_type": "code",
-        "colab": {}
+        "id": "9BKccvcTpj1k"
       },
       "source": [
         "ZIP = '/content/images.zip'\n",

--- a/models/hific/model.py
+++ b/models/hific/model.py
@@ -297,9 +297,9 @@ class HiFiC(object):
 
     with tf.name_scope("tfds"):
       if images_glob:
-        tf.logging.info(f'Using images_glob={images_glob}')
-        filenames = tf.data.Dataset.from_tensor_slices(
-          sorted(glob.glob(images_glob)))
+        images = sorted(glob.glob(images_glob))
+        tf.logging.info(f'Using images_glob={images_glob} ({len(images)} images)')
+        filenames = tf.data.Dataset.from_tensor_slices(images)
         dataset = filenames.map(lambda x: tf.image.decode_png(tf.read_file(x)))
       else:
         tf.logging.info(f'Using TFDS={tfds_arguments}')
@@ -368,7 +368,7 @@ class HiFiC(object):
         See build_input.
 
     Returns:
-      output_image and bpp if self.evaluation else None.
+      output_image and bitstrings if self.evaluation else None.
     """
     if input_images_d_steps is None:
       input_images_d_steps = []
@@ -402,7 +402,7 @@ class HiFiC(object):
     if self.evaluation:
       tf.logging.info("Evaluation mode: build_model done.")
       reconstruction = tf.clip_by_value(nodes_gen.reconstruction, 0, 255.)
-      return reconstruction, bpp_pair.total_qbpp, bitstrings
+      return reconstruction, bitstrings
 
     nodes_disc = []  # list of Nodes, one for every sub-batch of disc
     for i, sub_batch in enumerate(input_images_d_steps):

--- a/models/hific/model.py
+++ b/models/hific/model.py
@@ -453,6 +453,11 @@ class HiFiC(object):
     if self.training:
       self._train_op = train_op
 
+  def prepare_for_arithmetic_coding(self, sess):
+    """Run's the update op of the EntropyBottleneck."""
+    update_op = self._entropy_model.updates[0]
+    sess.run(update_op)
+
   def restore_trained_model(self, sess, ckpt_dir):
     """Restore a trained model for evaluation."""
     saver = tf.train.Saver()
@@ -522,7 +527,7 @@ class HiFiC(object):
     decoder_in = info.decoded
     total_nbpp = info.total_nbpp
     total_qbpp = info.total_qbpp
-    bitstrings = (info.bitstring, info.side_bitstring)
+    bitstream_tensors = info.bitstream_tensors
 
     reconstruction, reconstruction_scaled = \
         self._compute_reconstruction(
@@ -539,7 +544,7 @@ class HiFiC(object):
     nodes = Nodes(input_image, input_image_scaled,
                   reconstruction, reconstruction_scaled,
                   latent_quantized=decoder_in)
-    return nodes, BppPair(total_nbpp, total_qbpp), bitstrings
+    return nodes, BppPair(total_nbpp, total_qbpp), bitstream_tensors
 
   def _get_encoder_out(self,
                        input_image_scaled,

--- a/models/hific/train.py
+++ b/models/hific/train.py
@@ -37,7 +37,8 @@ def train(config_name, ckpt_dir, num_steps: int, auto_encoder_ckpt_dir,
   hific = model.HiFiC(config, helpers.ModelMode.TRAINING, lpips_weight_path,
                       auto_encoder_ckpt_dir, create_image_summaries)
 
-  dataset = hific.build_input(batch_size, crop_size, tfds_arguments)
+  dataset = hific.build_input(batch_size, crop_size,
+                              tfds_arguments=tfds_arguments)
   iterator = tf.data.make_one_shot_iterator(dataset)
   get_next = iterator.get_next()
 

--- a/models/hific/train.py
+++ b/models/hific/train.py
@@ -17,8 +17,6 @@
 import argparse
 import sys
 
-from absl import logging
-
 import tensorflow.compat.v1 as tf
 
 from . import configs
@@ -26,7 +24,7 @@ from . import helpers
 from . import model
 
 # Show custom tf.logging calls.
-logging.set_verbosity(logging.INFO)
+tf.logging.set_verbosity(tf.logging.INFO)
 
 SAVE_CHECKPOINT_STEPS = 1000
 
@@ -48,6 +46,7 @@ def train(config_name, ckpt_dir, num_steps: int, auto_encoder_ckpt_dir,
 
   hooks = hific.hooks + [tf.train.StopAtStepHook(last_step=num_steps)]
   global_step = tf.train.get_or_create_global_step()
+  tf.logging.info(f'\nStarting MonitoredTrainingSession at {ckpt_dir}\n')
 
   with tf.train.MonitoredTrainingSession(
       checkpoint_dir=ckpt_dir,

--- a/models/hific/train.py
+++ b/models/hific/train.py
@@ -60,7 +60,7 @@ def train(config_name, ckpt_dir, num_steps: int, auto_encoder_ckpt_dir,
       if sess.should_stop():
         break
       global_step_np, _ = sess.run([global_step, train_op])
-      global_step_np, _ = sess.run([global_step, train_op])
+      # TODO(nickj) This was not intended.
       # We do back to back training steps. If this is intended, we need to
       # log first step at 1, otherwise revert to 0.
       if global_step_np == 1:

--- a/models/hific/train.py
+++ b/models/hific/train.py
@@ -60,10 +60,7 @@ def train(config_name, ckpt_dir, num_steps: int, auto_encoder_ckpt_dir,
       if sess.should_stop():
         break
       global_step_np, _ = sess.run([global_step, train_op])
-      # TODO(nickj) This was not intended.
-      # We do back to back training steps. If this is intended, we need to
-      # log first step at 1, otherwise revert to 0.
-      if global_step_np == 1:
+      if global_step_np == 0:
         tf.logging.info('First iteration passed.')
       if global_step_np > 1 and global_step_np % 100 == 1:
         tf.logging.info(f'Iteration {global_step_np}')


### PR DESCRIPTION
- Remove "PRE-RELEASE" warning.
- Improve evaluate.py:
  - Do real arithmetic coding to report bitrate. This includes running the entropy model updates.
  - Support image folders as input (not just TFDS).
  - Report PSNR.
- Rename LayerNorm to ChannelNorm.
- Fix Colab to make it better to use:
  - Support different HiFiC models with drop down.
  - Support blindly running whole file.
  - Support skipping the upload cell.
  - support re-running with same files but potentially different model.
- Fix tf.logging statements not getting printed.
- Fix train.py doing back to back training.
