### PR TITLE
HiFiC for Camera Ready

### DIFF
--- a/models/hific/README.md
+++ b/models/hific/README.md
@@ -1,7 +1,5 @@
 # High-Fidelity Generative Image Compression
 
-## PRE-RELEASE
-
 <div align="center">
   <a href='https://hific.github.io'>
   <img src='https://hific.github.io/social/thumb.jpg' width="80%"/>
@@ -95,7 +93,6 @@ If you get slow training/stalling, try tweaking the `DATASET_NUM_PARALLEL` and
 
 The architecture is defined in `arch.py`, which is used to build the model from
 `model.py`. Our configurations are in `configs.py`.
-
 
 We release a _simplified_ trainer in `train.py` as a starting point for custom
 training. Note that it's using

--- a/models/hific/colab.ipynb
+++ b/models/hific/colab.ipynb
@@ -5,7 +5,8 @@
     "colab": {
       "name": "HiFiC_Interactive_Colab.ipynb",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -17,7 +18,20 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
+        "id": "ErOf16E05Dn7"
+      },
+      "source": [
+        "# High-Fidelity Generative Image Compression\n",
+        "\n",
+        "This colab can be used to compress images using HiFiC. This can also be achieved\n",
+        "by running `tfci.py`, as [explained in the README](https://github.com/tensorflow/compression/tree/master/models/hific#running-models-trained-by-us-locally).\n",
+        "\n",
+        "Please visit [hific.github.io](https://hific.github.io) for more information."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "Umer7W0VbITT"
       },
       "source": [
@@ -27,9 +41,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "LO_MNEQ7Bhbw",
-        "colab": {}
+        "id": "LO_MNEQ7Bhbw"
       },
       "source": [
         "%tensorflow_version 1.x\n",
@@ -44,7 +56,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "op4hPwy_mkPm"
       },
       "source": [
@@ -58,9 +69,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "x-yLUG_tmo3M",
-        "colab": {}
+        "id": "x-yLUG_tmo3M"
       },
       "source": [
         "import tensorflow as tf\n",
@@ -76,7 +85,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rQ9-8ZsTf7Hj"
       },
       "source": [
@@ -86,9 +94,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "vtd1l70Pf95V",
-        "colab": {}
+        "id": "vtd1l70Pf95V"
       },
       "source": [
         "import os\n",
@@ -109,9 +115,6 @@
         "DEFAULT_IMAGE_URL = ('https://storage.googleapis.com/hific/clic2020/'\n",
         "                     'images/originals/ad249bba099568403dc6b97bc37f8d74.png')\n",
         "\n",
-        "MODEL = 'hific-lo'\n",
-        "TMP_OUT = 'out.tfci'\n",
-        "\n",
         "os.makedirs(FILES_DIR, exist_ok=True)\n",
         "os.makedirs(OUT_DIR, exist_ok=True)\n",
         "\n",
@@ -128,12 +131,7 @@
         "  output_path = os.path.join(output_dir, os.path.basename(DEFAULT_IMAGE_URL))\n",
         "  print('Downloading', DEFAULT_IMAGE_URL, '\\n->', output_path)\n",
         "  urllib.request.urlretrieve(DEFAULT_IMAGE_URL, output_path)\n",
-        "\n",
-        "\n",
-        "print('Caching model...')\n",
-        "tfci.import_metagraph(MODEL)\n",
-        "print('Done')\n",
-        "      "
+        "\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -141,7 +139,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "4Ngs9WvmbTMH"
       },
       "source": [
@@ -151,26 +148,31 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "NgtIlL2ADCI2",
-        "colab": {}
+        "id": "NgtIlL2ADCI2"
       },
       "source": [
-        "#@title Loading Images { vertical-output: false, run: \"auto\", display-mode: \"form\" }\n",
+        "#@title Setup { vertical-output: false, run: \"auto\", display-mode: \"form\" }\n",
+        "#@markdown #### Custom Images\n",
         "#@markdown Tick the following if you want to upload your own images to compress.\n",
         "#@markdown Otherwise, a default image will be used.\n",
         "#@markdown \n",
         "#@markdown **Note**: We support JPG and PNG (without alpha channels).\n",
         "#@markdown \n",
         "\n",
-        "upload_custom_images = False #@param {type:\"boolean\"}\n",
+        "upload_custom_images = False #@param {type:\"boolean\", label:\"HI\"}\n",
         "\n",
         "if upload_custom_images:\n",
         "  uploaded = files.upload()\n",
         "  for name, content in uploaded.items():\n",
         "    with open(os.path.join(FILES_DIR, name), 'wb') as fout:\n",
         "      print('Writing', name, '...')\n",
-        "      fout.write(content)\n"
+        "      fout.write(content)\n",
+        "\n",
+        "#@markdown #### Select a model\n",
+        "#@markdown Different models target different bitrates.\n",
+        "\n",
+        "model = 'hific-lo' #@param [\"hific-lo\", \"hific-mi\", \"hific-hi\"]\n",
+        "\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -178,19 +180,32 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "e0C4vMqZsnqA",
-        "colab_type": "code",
-        "colab": {}
+        "id": "GYcbc2HupTRD"
+      },
+      "source": [
+        "if 'upload_custom_images' not in locals():\n",
+        "  print('ERROR: Please run the previous cell!')\n",
+        "  # Setting defaults anyway.\n",
+        "  upload_custom_images = False\n",
+        "  model = 'hific-lo'"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "e0C4vMqZsnqA"
       },
       "source": [
         "all_files = os.listdir(FILES_DIR)\n",
         "if not upload_custom_images or not all_files:\n",
-        "  print('Downloading default...')\n",
+        "  print('Downloading default image...')\n",
         "  get_default_image(FILES_DIR)\n",
         "  print()\n",
         "\n",
         "all_files = os.listdir(FILES_DIR)\n",
-        "print(f'Got following files ({len(all_files)}):')\n",
+        "print(f'Got the following files ({len(all_files)}):')\n",
         "\n",
         "for file_name in all_files:\n",
         "  img = Image.open(os.path.join(FILES_DIR, file_name))\n",
@@ -203,10 +218,22 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
+      "metadata": {
+        "id": "46eq2rCRpXzC"
+      },
+      "source": [
+        "print(f'Caching model \"{model}\"...')\n",
+        "tfci.import_metagraph(model)\n",
+        "print('Done')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
-        "id": "guX3Q_AsTE7-",
-        "colab_type": "text"
+        "id": "guX3Q_AsTE7-"
       },
       "source": [
         "# Compress images"
@@ -215,9 +242,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "kd02HOhLBj6e",
-        "colab": {}
+        "id": "kd02HOhLBj6e"
       },
       "source": [
         "SUPPORTED_EXT = {'.png', '.jpg'}\n",
@@ -246,17 +271,25 @@
         "    print('Skipping because of alpha channel:', file_name)\n",
         "    continue\n",
         "  file_name, _ = os.path.splitext(file_name)\n",
-        "  output_path = os.path.join(OUT_DIR, f'{file_name}.png')\n",
+        "\n",
+        "  compressed_path = os.path.join(OUT_DIR, f'{file_name}_{model}.tfci')\n",
+        "  output_path = os.path.join(OUT_DIR, f'{file_name}_{model}.png')\n",
+        "  \n",
         "  if os.path.isfile(output_path):\n",
-        "    print('Skipping', output_path, '-- exists already.')\n",
+        "    print('Exists already:', output_path)\n",
+        "    num_bytes = os.path.getsize(compressed_path)\n",
+        "    all_outputs.append(\n",
+        "      File(output_path, num_bytes,\n",
+        "           get_bpp(Image.open(full_path).size, num_bytes)))\n",
         "    continue\n",
         "\n",
-        "  print('Compressing', file_name, '...')\n",
-        "  tfci.compress(MODEL, full_path, TMP_OUT)\n",
-        "  num_bytes = os.path.getsize(TMP_OUT)\n",
+        "  print('Compressing', file_name, 'with', model, '...')\n",
+        "  tfci.compress(model, full_path, compressed_path)\n",
+        "  num_bytes = os.path.getsize(compressed_path)\n",
+        "  print(f'Compressed to {num_bytes} bytes.')\n",
         "\n",
         "  print('Decompressing...')\n",
-        "  tfci.decompress(TMP_OUT, output_path)\n",
+        "  tfci.decompress(compressed_path, output_path)\n",
         "  \n",
         "  all_outputs.append(\n",
         "      File(output_path, num_bytes,\n",
@@ -270,8 +303,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "HQhQQs-CTkgy",
-        "colab_type": "text"
+        "id": "HQhQQs-CTkgy"
       },
       "source": [
         "# Show output"
@@ -280,9 +312,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab_type": "code",
-        "id": "3nVCPeDnskD8",
-        "colab": {}
+        "id": "3nVCPeDnskD8"
       },
       "source": [
         "make_cell_large()  # Larger output window.\n",
@@ -299,8 +329,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4b-wkBnyrTAR",
-        "colab_type": "text"
+        "id": "4b-wkBnyrTAR"
       },
       "source": [
         "### Download all compressed images.\n",
@@ -317,9 +346,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "9BKccvcTpj1k",
-        "colab_type": "code",
-        "colab": {}
+        "id": "9BKccvcTpj1k"
       },
       "source": [
         "ZIP = '/content/images.zip'\n",

--- a/models/hific/evaluate.py
+++ b/models/hific/evaluate.py
@@ -18,57 +18,113 @@ NOTE: To evaluate models used in the paper, use tfci.py! See README.md.
 """
 
 import argparse
+import collections
 import itertools
 import os
+import glob
 import sys
 from PIL import Image
 
+import tensorflow_compression as tfc
 import tensorflow.compat.v1 as tf
+import numpy as np
 
 from . import configs
 from . import helpers
 from . import model
 
 
+# Show custom tf.logging calls.
+tf.logging.set_verbosity(tf.logging.INFO)
+
+
 def eval_trained_model(config_name,
                        ckpt_dir,
                        out_dir,
+                       images_glob,
                        tfds_arguments: helpers.TFDSArguments,
                        max_images=None):
   """Evaluate a trained model."""
   config = configs.get_config(config_name)
   hific = model.HiFiC(config, helpers.ModelMode.EVALUATION)
 
-  # Automatically uses the validation split.
+  # Note: Automatically uses the validation split for TFDS.
   dataset = hific.build_input(
-      batch_size=1, crop_size=None, tfds_arguments=tfds_arguments)
+    batch_size=1, crop_size=None,
+    images_glob=images_glob, tfds_arguments=tfds_arguments)
+  image_names = get_image_names(images_glob)
   iterator = tf.data.make_one_shot_iterator(dataset)
   get_next_image = iterator.get_next()
-
-  output_image, bpp = hific.build_model(**get_next_image)
   input_image = get_next_image['input_image']
+  output_image, bitstring = hific.build_model(**get_next_image)
 
   input_image = tf.cast(tf.round(input_image[0, ...]), tf.uint8)
   output_image = tf.cast(tf.round(output_image[0, ...]), tf.uint8)
 
   os.makedirs(out_dir, exist_ok=True)
 
+  accumulated_metrics = collections.defaultdict(list)
+
   with tf.Session() as sess:
     hific.restore_trained_model(sess, ckpt_dir)
+    hific.prepare_for_arithmetic_coding(sess)
+
     for i in itertools.count(0):
       if max_images and i == max_images:
         break
       try:
-        inp_np, otp_np, bpp_np = sess.run([input_image, output_image, bpp])
-        print(f'Image {i}: {bpp_np:.3} bpp, saving in {out_dir}...')
+        inp_np, otp_np, bitstring_np = \
+          sess.run([input_image, output_image, bitstring])
+
+        h, w, c = inp_np.shape
+        assert c == 3
+        bpp = get_arithmetic_coding_bpp(bitstring, bitstring_np, num_pixels=h * w)
+
+        metrics = {'psnr': get_psnr(inp_np, otp_np),
+                   'bpp_real': bpp}
+
+        metrics_str = ' / '.join(f'{metric}: {value:.5f}'
+                                 for metric, value in metrics.items())
+        print(f'Image {i: 4d}: {metrics_str}, saving in {out_dir}...')
+
+        for metric, value in metrics.items():
+          accumulated_metrics[metric].append(value)
+
+        # Save images.
+        name = image_names.get(i, f'img_{i:010d}')
         Image.fromarray(inp_np).save(
-            os.path.join(out_dir, f'img_{i:010d}inp.png'))
+            os.path.join(out_dir, f'{name}_inp.png'))
         Image.fromarray(otp_np).save(
-            os.path.join(out_dir, f'img_{i:010d}otp_{bpp_np:.3f}.png'))
+            os.path.join(out_dir, f'{name}_otp_{bpp:.3f}.png'))
+
       except tf.errors.OutOfRangeError:
-        print('No more inputs')
+        print('No more inputs.')
         break
+
+  print('\n'.join(f'{metric}: {np.mean(values)}'
+                  for metric, values in accumulated_metrics.items()))
   print('Done!')
+
+
+def get_arithmetic_coding_bpp(bitstring, bitstring_np, num_pixels):
+  """Calculate bitrate we obtain with arithmetic coding."""
+  # TODO(mentzer): Add `compress` and `decompress` methods.
+  packed = tfc.PackedTensors()
+  packed.pack(tensors=bitstring, arrays=bitstring_np)
+  return len(packed.string) * 8 / num_pixels
+
+
+def get_psnr(inp, otp):
+  mse = np.mean(np.square(inp.astype(np.float32) - otp.astype(np.float32)))
+  psnr = 20. * np.log10(255.) - 10. * np.log10(mse)
+  return psnr
+
+
+def get_image_names(images_glob):
+  if not images_glob:
+    return {}
+  return {i: os.path.splitext(os.path.basename(p))[0]
+          for i, p in enumerate(sorted(glob.glob(images_glob)))}
 
 
 def parse_args(argv):
@@ -83,6 +139,8 @@ def parse_args(argv):
                             'trained model are.'))
   parser.add_argument('--out_dir', required=True, help='Where to save outputs.')
 
+  parser.add_argument('--images_glob', help='If given, use TODO')
+
   helpers.add_tfds_arguments(parser)
 
   args = parser.parse_args(argv[1:])
@@ -91,6 +149,7 @@ def parse_args(argv):
 
 def main(args):
   eval_trained_model(args.config, args.ckpt_dir, args.out_dir,
+                     args.images_glob,
                      helpers.parse_tfds_arguments(args))
 
 

--- a/models/hific/model.py
+++ b/models/hific/model.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """HiFiC model code."""
 import collections
+import glob
 import itertools
 
 from compare_gan.gans import loss_lib as compare_gan_loss_lib
@@ -25,6 +26,7 @@ from . import helpers
 from .helpers import ModelMode
 from .helpers import ModelType
 from .helpers import TFDSArguments
+
 
 # How many dataset preprocessing processes to use.
 DATASET_NUM_PARALLEL = 8
@@ -246,8 +248,11 @@ class HiFiC(object):
   def num_steps_disc(self):
     return self._num_steps_disc
 
-  def build_input(self, batch_size, crop_size, tfds_arguments: TFDSArguments):
+  def build_input(self, batch_size, crop_size,
+                  images_glob=None, tfds_arguments: TFDSArguments=None):
     """Build input dataset."""
+    if not (images_glob or tfds_arguments):
+      raise ValueError("Need images_glob or tfds_arguments!")
 
     if self._setup_discriminator:
       # Unroll dataset for GAN training. If we unroll for N steps,
@@ -268,37 +273,47 @@ class HiFiC(object):
       def _batch_to_dict(batch):
         return dict(input_image=batch)
 
-    dataset = self._get_dataset(batch_size, crop_size, tfds_arguments)
+    dataset = self._get_dataset(batch_size, crop_size,
+                                images_glob, tfds_arguments)
     return dataset.map(_batch_to_dict)
 
-  def _get_dataset(self, batch_size, crop_size, tfds_arguments: TFDSArguments):
+  def _get_dataset(self, batch_size, crop_size,
+                   images_glob, tfds_arguments: TFDSArguments):
     """Build TFDS dataset.
 
     Args:
       batch_size: int, batch_size.
       crop_size: int, will random crop to this (crop_size, crop_size)
+      images_glob:
       tfds_arguments: argument for TFDS.
 
     Returns:
       Instance of tf.data.Dataset.
     """
-    split = "train" if self.training else "validation"
-
-    tf.logging.info("Building TFDS pipeline: %s, %s, %d, %d", tfds_arguments,
-                    split, batch_size, crop_size)
 
     crop_size_float = tf.constant(crop_size, tf.float32) if crop_size else None
     smallest_fac = tf.constant(0.75, tf.float32)
     biggest_fac = tf.constant(0.95, tf.float32)
 
     with tf.name_scope("tfds"):
-      builder = tfds.builder(
-          tfds_arguments.dataset_name, data_dir=tfds_arguments.downloads_dir)
-      builder.download_and_prepare()
-      dataset = builder.as_dataset(split=split)
+      if images_glob:
+        images = sorted(glob.glob(images_glob))
+        tf.logging.info(f'Using images_glob={images_glob} ({len(images)} images)')
+        filenames = tf.data.Dataset.from_tensor_slices(images)
+        dataset = filenames.map(lambda x: tf.image.decode_png(tf.read_file(x)))
+      else:
+        tf.logging.info(f'Using TFDS={tfds_arguments}')
+        builder = tfds.builder(
+            tfds_arguments.dataset_name, data_dir=tfds_arguments.downloads_dir)
+        builder.download_and_prepare()
+        split = "train" if self.training else "validation"
+        dataset = builder.as_dataset(split=split)
 
       def _preprocess(features):
-        image = features[tfds_arguments.features_key]
+        if images_glob:
+          image = features
+        else:
+          image = features[tfds_arguments.features_key]
         if not crop_size:
           return image
         tf.logging.info("Scaling down %s and cropping to %d x %d", image,
@@ -353,7 +368,7 @@ class HiFiC(object):
         See build_input.
 
     Returns:
-      output_image and bpp if self.evaluation else None.
+      output_image and bitstrings if self.evaluation else None.
     """
     if input_images_d_steps is None:
       input_images_d_steps = []
@@ -381,17 +396,18 @@ class HiFiC(object):
     global_step = tf.train.get_or_create_global_step()
 
     # Compute output graph.
-    nodes_gen, bpp_pair = self._compute_compression_graph(input_image)
+    nodes_gen, bpp_pair, bitstrings = \
+      self._compute_compression_graph(input_image)
 
     if self.evaluation:
       tf.logging.info("Evaluation mode: build_model done.")
       reconstruction = tf.clip_by_value(nodes_gen.reconstruction, 0, 255.)
-      return reconstruction, bpp_pair.total_qbpp
+      return reconstruction, bitstrings
 
     nodes_disc = []  # list of Nodes, one for every sub-batch of disc
     for i, sub_batch in enumerate(input_images_d_steps):
       with tf.name_scope("sub_batch_disc_{}".format(i)):
-        nodes, _ = self._compute_compression_graph(sub_batch,
+        nodes, _, _ = self._compute_compression_graph(sub_batch,
                                                    create_summaries=False)
         nodes_disc.append(nodes)
 
@@ -436,6 +452,11 @@ class HiFiC(object):
 
     if self.training:
       self._train_op = train_op
+
+  def prepare_for_arithmetic_coding(self, sess):
+    """Run's the update op of the EntropyBottleneck."""
+    update_op = self._entropy_model.updates[0]
+    sess.run(update_op)
 
   def restore_trained_model(self, sess, ckpt_dir):
     """Restore a trained model for evaluation."""
@@ -506,6 +527,7 @@ class HiFiC(object):
     decoder_in = info.decoded
     total_nbpp = info.total_nbpp
     total_qbpp = info.total_qbpp
+    bitstream_tensors = info.bitstream_tensors
 
     reconstruction, reconstruction_scaled = \
         self._compute_reconstruction(
@@ -522,7 +544,7 @@ class HiFiC(object):
     nodes = Nodes(input_image, input_image_scaled,
                   reconstruction, reconstruction_scaled,
                   latent_quantized=decoder_in)
-    return nodes, BppPair(total_nbpp, total_qbpp)
+    return nodes, BppPair(total_nbpp, total_qbpp), bitstream_tensors
 
   def _get_encoder_out(self,
                        input_image_scaled,


### PR DESCRIPTION
- Improve evaluate.py:
  - Do real arithmetic coding to report bitrate. This includes running the entropy model updates.
  - Support image folders as input (not just TFDS).
  - Report PSNR.
- Rename LayerNorm to ChannelNorm.
- Fix Colab to make it better to use:
  - Support different HiFiC models with drop down.
  - Support blindly running whole file.
  - Support skipping the upload cell.
  - support re-running with same files but potentially different model.
- Fix tf.logging statements not getting printed.
- Fix train.py doing back to back training.