### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/models/hific/archs.py
+++ b/models/hific/archs.py
@@ -654,7 +654,7 @@ class FactorizedPriorLayer(tf.keras.layers.Layer):
 def estimate_entropy(entropy_model, inputs, spatial_shape=None) -> EntropyInfo:
   """Compresses `inputs` with the given entropy model and estimates entropy.
 
-  Arguments:
+  Args:
     entropy_model: An `EntropyModel` instance.
     inputs: The input tensor to be fed to the entropy model.
     spatial_shape: Shape of the input image (HxW). Must be provided for

--- a/models/hific/helpers.py
+++ b/models/hific/helpers.py
@@ -85,6 +85,6 @@ def add_tfds_arguments(parser):
       help="Name of the TFDS feature to use.")
 
 
-def parse_tfds_arguments(args) -> TFDSArgs:
+def parse_tfds_arguments(args) -> TFDSArguments:
   return TFDSArguments(args.tfds_dataset_name, args.tfds_features_key,
                        args.tfds_downloads_dir)

--- a/models/hific/helpers.py
+++ b/models/hific/helpers.py
@@ -85,6 +85,6 @@ def add_tfds_arguments(parser):
       help="Name of the TFDS feature to use.")
 
 
-def parse_tfds_arguments(args) -> TFDSArguments:
+def parse_tfds_arguments(args) -> TFDSArgs:
   return TFDSArguments(args.tfds_dataset_name, args.tfds_features_key,
                        args.tfds_downloads_dir)

--- a/tensorflow_compression/python/distributions/deep_factorized.py
+++ b/tensorflow_compression/python/distributions/deep_factorized.py
@@ -69,7 +69,7 @@ class DeepFactorized(tfp.distributions.Distribution):
                allow_nan_stats=False, dtype=tf.float32, name="DeepFactorized"):
     """Initializer.
 
-    Arguments:
+    Args:
       batch_shape: Iterable of integers. The desired batch shape for the
         `Distribution` (rightmost dimensions which are assumed independent, but
         not identically distributed).
@@ -164,7 +164,7 @@ class DeepFactorized(tfp.distributions.Distribution):
   def _logits_cumulative(self, inputs):
     """Evaluate logits of the cumulative densities.
 
-    Arguments:
+    Args:
       inputs: The values at which to evaluate the cumulative densities.
 
     Returns:

--- a/tensorflow_compression/python/distributions/helpers.py
+++ b/tensorflow_compression/python/distributions/helpers.py
@@ -42,7 +42,7 @@ def estimate_tails(func, target, shape, dtype):
   This operation is vectorized. The tensor shape of `x` is given by `shape`, and
   `target` must have a shape that is broadcastable to the output of `func(x)`.
 
-  Arguments:
+  Args:
     func: A callable that computes cumulative distribution function, survival
       function, or similar.
     target: The desired target value.
@@ -107,7 +107,7 @@ def quantization_offset(distribution):
   Note the offset is always in the range [-.5, .5] as it is assumed to be
   combined with a round quantizer.
 
-  Arguments:
+  Args:
     distribution: A `tfp.distributions.Distribution` object.
 
   Returns:
@@ -142,7 +142,7 @@ def lower_tail(distribution, tail_mass):
   functionality of the range coder implementation (using a Golomb-like
   universal code).
 
-  Arguments:
+  Args:
     distribution: A `tfp.distributions.Distribution` object.
     tail_mass: Float between 0 and 1. Desired probability mass for the tails.
 
@@ -178,7 +178,7 @@ def upper_tail(distribution, tail_mass):
   functionality of the range coder implementation (using a Golomb-like
   universal code).
 
-  Arguments:
+  Args:
     distribution: A `tfp.distributions.Distribution` object.
     tail_mass: Float between 0 and 1. Desired probability mass for the tails.
 

--- a/tensorflow_compression/python/distributions/round_adapters.py
+++ b/tensorflow_compression/python/distributions/round_adapters.py
@@ -44,7 +44,7 @@ class MonotonicAdapter(tfp.distributions.Distribution):
   def __init__(self, base, name="MonotonicAdapter"):
     """Initializer.
 
-    Arguments:
+    Args:
       base: A `tfp.distributions.Distribution` object representing a
         continuous-valued random variable.
       name: String. A name for this distribution.
@@ -196,7 +196,7 @@ class NoisyRoundAdapter(uniform_noise.UniformNoiseAdapter):
   def __init__(self, base, name="NoisyRoundAdapter"):
     """Initializer.
 
-    Arguments:
+    Args:
       base: A `tfp.distributions.Distribution` object representing a
         continuous-valued random variable.
       name: String. A name for this distribution.
@@ -225,7 +225,7 @@ class SoftRoundAdapter(MonotonicAdapter):
   def __init__(self, base, alpha, name="SoftRoundAdapter"):
     """Initializer.
 
-    Arguments:
+    Args:
       base: A `tfp.distributions.Distribution` object representing a
         continuous-valued random variable.
       alpha: Float or tf.Tensor. Controls smoothness of the approximation.
@@ -247,7 +247,7 @@ class NoisySoftRoundAdapter(uniform_noise.UniformNoiseAdapter):
   def __init__(self, base, alpha, name="NoisySoftRoundAdapter"):
     """Initializer.
 
-    Arguments:
+    Args:
       base: A `tfp.distributions.Distribution` object representing a
         continuous-valued random variable.
       alpha: Float or tf.Tensor. Controls smoothness of soft round.

--- a/tensorflow_compression/python/distributions/uniform_noise.py
+++ b/tensorflow_compression/python/distributions/uniform_noise.py
@@ -36,7 +36,7 @@ def _logsum_expbig_minus_expsmall(big, small):
   This assumes `small <= big` and arguments that can be broadcast against each
   other.
 
-  Arguments:
+  Args:
     big: Floating-point `tf.Tensor`.
     small: Floating-point `tf.Tensor`.
 
@@ -73,7 +73,7 @@ class UniformNoiseAdapter(tfp.distributions.Distribution):
   def __init__(self, base, name="UniformNoiseAdapter"):
     """Initializer.
 
-    Arguments:
+    Args:
       base: A `tfp.distributions.Distribution` object representing a
         continuous-valued random variable.
       name: String. A name for this distribution.

--- a/tensorflow_compression/python/entropy_models/continuous_base.py
+++ b/tensorflow_compression/python/entropy_models/continuous_base.py
@@ -51,7 +51,7 @@ class ContinuousEntropyModelBase(tf.Module, metaclass=abc.ABCMeta):
   ):
     """Initializes the instance.
 
-    Arguments:
+    Args:
       prior: A `tfp.distributions.Distribution` object. A density model fitting
         the marginal distribution of the bottleneck data with additive uniform
         noise, which is shared a priori between the sender and the receiver. For
@@ -226,7 +226,7 @@ class ContinuousEntropyModelBase(tf.Module, metaclass=abc.ABCMeta):
     `compression=True`, and then distribute the model to a sender and a
     receiver.
 
-    Arguments:
+    Args:
       prior: The `tfp.distributions.Distribution` object (see initializer).
     """
     # TODO(jonycgn, relational): Consider not using offset when soft quantization
@@ -343,7 +343,7 @@ class ContinuousEntropyModelBase(tf.Module, metaclass=abc.ABCMeta):
   def from_config(cls, config):
     """Instantiates an entropy model from a configuration dictionary.
 
-    Arguments:
+    Args:
       config: A `dict`, typically the output of `get_config`.
 
     Returns:

--- a/tensorflow_compression/python/entropy_models/continuous_batched.py
+++ b/tensorflow_compression/python/entropy_models/continuous_batched.py
@@ -83,7 +83,7 @@ class ContinuousBatchedEntropyModel(continuous_base.ContinuousEntropyModelBase):
                no_variables=False):
     """Initializes the instance.
 
-    Arguments:
+    Args:
       prior: A `tfp.distributions.Distribution` object. A density model fitting
         the marginal distribution of the bottleneck data with additive uniform
         noise, which is shared a priori between the sender and the receiver. For
@@ -167,7 +167,7 @@ class ContinuousBatchedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     """Perturbs a tensor with (quantization) noise and estimates bitcost.
 
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be compressed. Must have at
         least `self.coding_rank` dimensions, and the innermost dimensions must
         be broadcastable to `self.prior_shape`.
@@ -209,7 +209,7 @@ class ContinuousBatchedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     The gradient of this rounding operation is overridden with the identity
     (straight-through gradient estimator).
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be quantized. The innermost
         dimensions must be broadcastable to `self.prior_shape`.
 
@@ -231,7 +231,7 @@ class ContinuousBatchedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     i.e. are compressed into one string each. Any additional dimensions to the
     left are treated as batch dimensions.
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be compressed. Must have at
         least `self.coding_rank` dimensions, and the innermost dimensions must
         be broadcastable to `self.prior_shape`.
@@ -279,7 +279,7 @@ class ContinuousBatchedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     Reconstructs the quantized tensor from bit strings produced by `compress()`.
     It is necessary to provide a part of the output shape in `broadcast_shape`.
 
-    Arguments:
+    Args:
       strings: `tf.Tensor` containing the compressed bit strings.
       broadcast_shape: Iterable of ints. The part of the output tensor shape
         between the shape of `strings` on the left and
@@ -338,7 +338,7 @@ class ContinuousBatchedEntropyModel(continuous_base.ContinuousEntropyModelBase):
   def from_config(cls, config):
     """Instantiates an entropy model from a configuration dictionary.
 
-    Arguments:
+    Args:
       config: A `dict`, typically the output of `get_config`.
 
     Returns:

--- a/tensorflow_compression/python/entropy_models/continuous_indexed.py
+++ b/tensorflow_compression/python/entropy_models/continuous_indexed.py
@@ -140,7 +140,7 @@ class ContinuousIndexedEntropyModel(continuous_base.ContinuousEntropyModelBase):
                no_variables=False):
     """Initializes the instance.
 
-    Arguments:
+    Args:
       prior_fn: A callable returning a `tfp.distributions.Distribution` object,
         typically a `Distribution` class or factory function. This is a density
         model fitting the marginal distribution of the bottleneck data with
@@ -285,7 +285,7 @@ class ContinuousIndexedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     """Perturbs a tensor with (quantization) noise and estimates bitcost.
 
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be compressed.
       indexes: `tf.Tensor` specifying the scalar distribution for each element
         in `bottleneck`. See class docstring for examples.
@@ -340,7 +340,7 @@ class ContinuousIndexedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     The gradient of this rounding operation is overridden with the identity
     (straight-through gradient estimator).
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be quantized.
       indexes: `tf.Tensor` specifying the scalar distribution for each element
         in `bottleneck`. See class docstring for examples.
@@ -365,7 +365,7 @@ class ContinuousIndexedEntropyModel(continuous_base.ContinuousEntropyModelBase):
     i.e. are compressed into one string each. Any additional dimensions to the
     left are treated as batch dimensions.
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be compressed.
       indexes: `tf.Tensor` specifying the scalar distribution for each element
         in `bottleneck`. See class docstring for examples.
@@ -412,7 +412,7 @@ class ContinuousIndexedEntropyModel(continuous_base.ContinuousEntropyModelBase):
 
     Reconstructs the quantized tensor from bit strings produced by `compress()`.
 
-    Arguments:
+    Args:
       strings: `tf.Tensor` containing the compressed bit strings.
       indexes: `tf.Tensor` specifying the scalar distribution for each output
         element. See class docstring for examples.
@@ -478,7 +478,7 @@ class LocationScaleIndexedEntropyModel(ContinuousIndexedEntropyModel):
                range_coder_precision=12, no_variables=False):
     """Initializes the instance.
 
-    Arguments:
+    Args:
       prior_fn: A callable returning a `tfp.distributions.Distribution` object,
         typically a `Distribution` class or factory function. This is a density
         model fitting the marginal distribution of the bottleneck data with
@@ -527,7 +527,7 @@ class LocationScaleIndexedEntropyModel(ContinuousIndexedEntropyModel):
   def __call__(self, bottleneck, scale_indexes, loc=None, training=True):
     """Perturbs a tensor with (quantization) noise and estimates bitcost.
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be compressed.
       scale_indexes: `tf.Tensor` indexing the scale parameter for each element
         in `bottleneck`. Must have the same shape as `bottleneck`.
@@ -566,7 +566,7 @@ class LocationScaleIndexedEntropyModel(ContinuousIndexedEntropyModel):
     The gradient of this rounding operation is overridden with the identity
     (straight-through gradient estimator).
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be quantized.
       scale_indexes: `tf.Tensor` indexing the scale parameter for each element
         in `bottleneck`. Must have the same shape as `bottleneck`.
@@ -596,7 +596,7 @@ class LocationScaleIndexedEntropyModel(ContinuousIndexedEntropyModel):
     i.e. are compressed into one string each. Any additional dimensions to the
     left are treated as batch dimensions.
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing the data to be compressed.
       scale_indexes: `tf.Tensor` indexing the scale parameter for each element
         in `bottleneck`. Must have the same shape as `bottleneck`.
@@ -620,7 +620,7 @@ class LocationScaleIndexedEntropyModel(ContinuousIndexedEntropyModel):
 
     Reconstructs the quantized tensor from bit strings produced by `compress()`.
 
-    Arguments:
+    Args:
       strings: `tf.Tensor` containing the compressed bit strings.
       scale_indexes: `tf.Tensor` indexing the scale parameter for each output
         element.

--- a/tensorflow_compression/python/entropy_models/universal.py
+++ b/tensorflow_compression/python/entropy_models/universal.py
@@ -84,7 +84,7 @@ class UniversalBatchedEntropyModel(
                no_variables=False):
     """Initializes the instance.
 
-    Arguments:
+    Args:
       prior: A `tfp.distributions.Distribution` object. A density model fitting
         the marginal distribution of the bottleneck data with additive uniform
         noise, which is shared a priori between the sender and the receiver. For
@@ -182,7 +182,7 @@ class UniversalBatchedEntropyModel(
   def __call__(self, bottleneck, training=True):
     """Perturbs a tensor with additive uniform noise and estimates bitcost.
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing a non-perturbed bottleneck. Must have
         at least `self.coding_rank` dimensions.
       training: Boolean. If `False`, computes the bitcost using discretized
@@ -255,7 +255,7 @@ class UniversalIndexedEntropyModel(
                num_noise_levels=15):
     """Initializes the instance.
 
-    Arguments:
+    Args:
       prior_fn: A callable returning a `tfp.distributions.Distribution` object,
         typically a `Distribution` class or factory function. This is a density
         model fitting the marginal distribution of the bottleneck data with
@@ -388,7 +388,7 @@ class UniversalIndexedEntropyModel(
   def __call__(self, bottleneck, indexes, training=True):
     """Perturbs a tensor with additive uniform noise and estimates bitcost.
 
-    Arguments:
+    Args:
       bottleneck: `tf.Tensor` containing a non-perturbed bottleneck. Must have
         at least `self.coding_rank` dimensions.
       indexes: `tf.Tensor` specifying the scalar distribution for each element

--- a/tensorflow_compression/python/layers/entropy_models.py
+++ b/tensorflow_compression/python/layers/entropy_models.py
@@ -42,7 +42,7 @@ class EntropyModel(tf.keras.layers.Layer):
                range_coder_precision=16, **kwargs):
     """Initializer.
 
-    Arguments:
+    Args:
       tail_mass: Float, between 0 and 1. The bottleneck layer automatically
         determines the range of input values based on their frequency of
         occurrence. Values occurring in the tails of the distributions will not
@@ -87,7 +87,7 @@ class EntropyModel(tf.keras.layers.Layer):
   def _quantize(self, inputs, mode):
     """Perturb or quantize a `Tensor` and optionally dequantize.
 
-    Arguments:
+    Args:
       inputs: `Tensor`. The input values.
       mode: String. Can take on one of three values: `'noise'` (adds uniform
         noise), `'dequantize'` (quantizes and dequantizes), and `'symbols'`
@@ -105,7 +105,7 @@ class EntropyModel(tf.keras.layers.Layer):
 
     The opposite to `_quantize(inputs, mode='symbols')`.
 
-    Arguments:
+    Args:
       inputs: `Tensor`. The range coder symbols.
       mode: String. Must be `'dequantize'`.
 
@@ -118,7 +118,7 @@ class EntropyModel(tf.keras.layers.Layer):
   def _likelihood(self, inputs):
     """Compute the likelihood of the inputs under the model.
 
-    Arguments:
+    Args:
       inputs: `Tensor`. The input values.
 
     Returns:
@@ -147,7 +147,7 @@ class EntropyModel(tf.keras.layers.Layer):
   def call(self, inputs, training):
     """Pass a tensor through the bottleneck.
 
-    Arguments:
+    Args:
       inputs: The tensor to be passed through the bottleneck.
       training: Boolean. If `True`, returns a differentiable approximation of
         the inputs, and their likelihoods under the modeled probability
@@ -188,7 +188,7 @@ class EntropyModel(tf.keras.layers.Layer):
   def compress(self, inputs):
     """Compress inputs and store their binary representations into strings.
 
-    Arguments:
+    Args:
       inputs: `Tensor` with values to be compressed.
 
     Returns:
@@ -250,7 +250,7 @@ class EntropyModel(tf.keras.layers.Layer):
   def decompress(self, strings, **kwargs):
     """Decompress values from their compressed string representations.
 
-    Arguments:
+    Args:
       strings: A string `Tensor` vector containing the compressed data.
       **kwargs: Model-specific keyword arguments.
 
@@ -341,7 +341,7 @@ class EntropyBottleneck(EntropyModel):
                data_format="channels_last", **kwargs):
     """Initializer.
 
-    Arguments:
+    Args:
       init_scale: Float. A scaling factor determining the initial width of the
         probability densities. This should be chosen big enough so that the
         range of values of the layer inputs roughly falls within the interval
@@ -401,7 +401,7 @@ class EntropyBottleneck(EntropyModel):
   def _logits_cumulative(self, inputs, stop_gradient):
     """Evaluate logits of the cumulative densities.
 
-    Arguments:
+    Args:
       inputs: The values at which to evaluate the cumulative densities, expected
         to be a `Tensor` of shape `(channels, 1, batch)`.
       stop_gradient: Boolean. Whether to add `tf.stop_gradient` calls so
@@ -442,7 +442,7 @@ class EntropyBottleneck(EntropyModel):
     and then uses that to create the probability mass functions and the discrete
     cumulative density functions used by the range coder.
 
-    Arguments:
+    Args:
       input_shape: Shape of the input tensor, used to get the number of
         channels.
 
@@ -686,7 +686,7 @@ class EntropyBottleneck(EntropyModel):
   def decompress(self, strings, shape, channels=None):
     """Decompress values from their compressed string representations.
 
-    Arguments:
+    Args:
       strings: A string `Tensor` vector containing the compressed data.
       shape: A `Tensor` vector of int32 type. Contains the shape of the tensor
         to be decompressed, excluding the batch dimension.
@@ -713,7 +713,7 @@ class SymmetricConditional(EntropyModel):
                scale_bound=None, mean=None, indexes=None, **kwargs):
     """Initializer.
 
-    Arguments:
+    Args:
       scale: `Tensor`, the scale parameters for the conditional distributions.
       scale_table: Iterable of positive floats. For range coding, the scale
         parameters in `scale` can't be used, because the probability tables need
@@ -776,7 +776,7 @@ class SymmetricConditional(EntropyModel):
     Note: This function should be optimized to give the best possible numerical
     accuracy for negative input values.
 
-    Arguments:
+    Args:
       inputs: `Tensor`. The values at which to evaluate the cumulative density.
 
     Returns:
@@ -791,7 +791,7 @@ class SymmetricConditional(EntropyModel):
     This returns the inverse of the standardized cumulative function for a
     scalar.
 
-    Arguments:
+    Args:
       quantile: Float. The values at which to evaluate the quantile function.
 
     Returns:
@@ -808,7 +808,7 @@ class SymmetricConditional(EntropyModel):
     uses this index tensor to determine the starting positions of the PMFs for
     each scale.
 
-    Arguments:
+    Args:
       input_shape: Shape of the input tensor.
 
     Raises:
@@ -945,7 +945,7 @@ class SymmetricConditional(EntropyModel):
   def decompress(self, strings):  # pylint:disable=useless-super-delegation
     """Decompress values from their compressed string representations.
 
-    Arguments:
+    Args:
       strings: A string `Tensor` vector containing the compressed data.
 
     Returns:

--- a/tensorflow_compression/python/layers/gdn.py
+++ b/tensorflow_compression/python/layers/gdn.py
@@ -65,7 +65,7 @@ class GDN(tf.keras.layers.Layer):
                **kwargs):
     """Initializer.
 
-    Arguments:
+    Args:
       inverse: Boolean. If `False` (default), compute GDN response. If `True`,
         compute IGDN response (one step of fixed point iteration to invert GDN;
         the division is replaced by multiplication).

--- a/tensorflow_compression/python/layers/parameterizers.py
+++ b/tensorflow_compression/python/layers/parameterizers.py
@@ -70,7 +70,7 @@ class StaticParameterizer(Parameterizer):
   def __init__(self, value):
     """Initializer.
 
-    Arguments:
+    Args:
       value: Either a constant or `Tensor` value, or a callable which returns
         such a thing given a shape and dtype argument (for example, an
         initializer).
@@ -102,7 +102,7 @@ class RDFTParameterizer(Parameterizer):
   def __init__(self, dc=True):
     """Initializer.
 
-    Arguments:
+    Args:
       dc: Boolean. If `False`, the DC component of the kernel RDFTs is not
         represented, forcing the filters to be highpass. Defaults to `True`.
     """
@@ -165,7 +165,7 @@ class NonnegativeParameterizer(Parameterizer):
   def __init__(self, minimum=0, reparam_offset=2 ** -18):
     """Initializer.
 
-    Arguments:
+    Args:
       minimum: Float. Lower bound for parameters (defaults to zero).
       reparam_offset: Float. Offset added to the reparameterization of beta and
         gamma. The parameterization of beta and gamma as their square roots lets

--- a/tensorflow_compression/python/layers/signal_conv.py
+++ b/tensorflow_compression/python/layers/signal_conv.py
@@ -197,7 +197,7 @@ class _SignalConv(tf.keras.layers.Layer):
                **kwargs):
     """Initializer.
 
-    Arguments:
+    Args:
       filters: Integer. If `not channel_separable`, specifies the total number
         of filters, which is equal to the number of output channels. Otherwise,
         specifies the number of filters per channel, which makes the number of


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420