### PR TITLE
Updated LPIPS Class for TF2 Compatibility

### DIFF
--- a/models/hific/model.py
+++ b/models/hific/model.py
@@ -846,14 +846,14 @@ class LPIPSLoss(object):
     def wrap_frozen_graph(graph_def, inputs, outputs):
       def _imports_graph_def():
         tf.graph_util.import_graph_def(graph_def, name="")
-      wrapped_import = tf.wrap_function(_imports_graph_def, [])
+      wrapped_import = tf.compat.v1.wrap_function(_imports_graph_def, [])
       import_graph = wrapped_import.graph
       return wrapped_import.prune(
           tf.nest.map_structure(import_graph.as_graph_element, inputs),
           tf.nest.map_structure(import_graph.as_graph_element, outputs))
 
     # Pack LPIPS network into a tf function
-    graph_def = tf.GraphDef()
+    graph_def = tf.compat.v1.GraphDef()
     with open(weight_path, "rb") as f:
       graph_def.ParseFromString(f.read())
     self._lpips_func = tf.function(


### PR DESCRIPTION
Changed deprecated TF1 calls to their respective TF2 counterparts